### PR TITLE
Initial CI config

### DIFF
--- a/.circleci/ci-run.sh
+++ b/.circleci/ci-run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+source .venv/bin/activate
+
+python3 -m unittest discover

--- a/.circleci/circleci-readme.md
+++ b/.circleci/circleci-readme.md
@@ -1,0 +1,24 @@
+CI Debug Notes
+================
+To validate some circleci stuff, I was able to run a “build locally” using the steps below.
+The local build runs in a docker container.
+
+  * (Once) Install circleci client (`brew install circleci`)
+
+  * Convert the “real” config.yml into a self contained (non-workspace) config via:
+
+        circleci config process .circleci/config.yml > .circleci/local-config.yml
+
+  * Run a local build with the following command:
+          
+        circleci local execute -c .circleci/local-config.yml --job 'build'
+
+    With the above command, operations that cannot occur during a local build will show an error like this:
+     
+      ```
+      ... Error: FAILED with error not supported
+      ```
+    
+      However, the build will proceed and can complete “successfully”, which allows you to verify scripts in your config, etc.
+      
+      If the build does complete successfully, you should see a happy yellow `Success!` message.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,31 @@
+version: 2.1
+jobs:
+  build:
+    docker: # run the steps with Docker
+      - image: circleci/python:3.6.4
+        environment: # environment variables for primary container
+          PIPENV_VENV_IN_PROJECT: true
+    steps:
+      - checkout
+      - run: sudo chown -R circleci:circleci /usr/local/bin
+      - run: sudo chown -R circleci:circleci /usr/local/lib/python3.6/site-packages
+      - restore_cache:
+          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
+          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+      - run:
+          command: |
+            sudo .circleci/ci-setup.sh
+      - save_cache: # cache Python dependencies using checksum of Pipfile as the cache-key
+          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          paths:
+            - ".venv"
+            - "/usr/local/bin"
+            - "/usr/local/lib/python3.6/site-packages"
+      - run:
+          command: |
+            .circleci/ci-run.sh
+      - store_test_results: # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
+          path: test-results
+      - store_artifacts: # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
+          path: test-results
+          destination: tr1

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.pdf
 successmetrics.json
 .venv
+/.circleci/local-config.yml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # IQ Success Metrics
 
+[![CircleCI](https://circleci.com/gh/sonatype-nexus-community/iq-success-metrics.svg?style=svg)](https://circleci.com/gh/sonatype-nexus-community/iq-success-metrics)
+
 ## Overview
 
 Nexus IQ Server has a number of REST APIs that allow you to automate certain tasks as well as quickly retrieve IQ server data. One of those APIs is the Success Metrics Data API which collects all the violations and other measurements and shares them as counters inside a JSON dictionary. In order to better capture the results, we have developed a Python script to collect, aggregate and process the counters into outcome-based metrics. We can use these outcome-based metrics to measure progression toward your PDOs.


### PR DESCRIPTION
Continuous Integration config - take one. 
Known rough spots:

  * cache dirs probably not right yet (restore_cache, save_cache)
  * no real tests to run
  * I'm sure there's more rough edges, but at least this gets things started.

[.circleci/circleci-readme.md](.circleci/circleci-readme.md) includes steps run a CI build locally in a Docker container.