### PR TITLE
add a command line option to disable SSL Certificate validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The optional arguments are:
 -a AUTH, --auth AUTH (in the format user:password, by default admin:admin123)
 -s SCOPE, --scope SCOPE (number of weeks from current one to gather data from. Default value is six weeks)
 -u URL, --url URL (URL for IQ server, by default http://localhost:8070)
+-k, --insecure (Disable SSL Certificate Validation)
 -i APPID, --appId APPID (list of application IDs, application Names, application Public IDs or combination thereof to filter from all available data. Default is all available data)
 -o ORGID, --orgId ORGID (list of organization IDs, organization Names or combination thereof to filter from all available data. Default is all available data)
 -p, --pretty (indents the JSON printout 4 spaces. Default is no indentation)

--- a/README_non_docker.md
+++ b/README_non_docker.md
@@ -182,6 +182,7 @@ The optional arguments are:
 -a AUTH, --auth AUTH (in the format user:password, by default admin:admin123 )
 -s SCOPE, --scope SCOPE (number of weeks from current one to gather data from. Default value is six weeks)
 -u URL, --url URL (URL for IQ server, by default http://localhost:8070 )
+-k, --insecure (Disable SSL Certificate Validation)
 -i APPID, --appId APPID (list of application IDs, application Names, application Public IDs or combination thereof to filter from all available data. Default is all available data)
 -o ORGID, --orgId ORGID (list of organization IDs, organization Names or combination thereof to filter from all available data. Default is all available data)
 -p, --pretty (indents the JSON printout 4 spaces. Default is no indentation)

--- a/success_metrics.py
+++ b/success_metrics.py
@@ -34,6 +34,7 @@ def main():
         parser.add_argument('-a','--auth',   help='', default="admin:admin123", required=False)
         parser.add_argument('-s','--scope',  help='', type=int, default="6", required=False)
         parser.add_argument('-u','--url',    help='', default="http://localhost:8070", required=False)
+        parser.add_argument('-k','--insecure', help='', action='store_true', required=False)
         parser.add_argument('-i','--appId',  help='', required=False)
         parser.add_argument('-o','--orgId',  help='', required=False)
         parser.add_argument('-p','--pretty', help='', action='store_true', required=False)
@@ -44,6 +45,11 @@ def main():
         args = vars(parser.parse_args())
         creds = args["auth"].split(":",1)
         iq_session.auth = requests.auth.HTTPBasicAuth(str(creds[0]), str(creds[1]) )
+
+        if args["insecure"] == True:
+            print("WARNING: Ignoring SSL Certificate Validation")
+            iq_session.verify = False
+
         if not os.path.exists("output"):
             os.mkdir("output")
 


### PR DESCRIPTION
For some IQ Server environments, a self-signed certificate or corporate certificate authority signed certificate is used, which causes the API requests to IQ Server to fail as untrusted. The quick and dirty fix is to disable certificate validation. Long term, we could add the option to trust custom certificates, but that is a little more work on the user side to get the certificate from IQ Server in the first place.

This pull request makes the following changes:
* add a command line option to success_metrics.py to disable SSL Certificate validation

cc @DarthHater @cmorenoserrano 
